### PR TITLE
Make setting permissions optional on startup

### DIFF
--- a/skeleton/docker-entrypoint.sh
+++ b/skeleton/docker-entrypoint.sh
@@ -16,7 +16,7 @@ USER="$(id -u)"
 [ -z ${SET_PERMISSIONS+x} ] && export SET_PERMISSIONS=false
 mkdir -p /data/filestorage /data/blobstorage /data/cache /data/log $CLIENT_HOME
 if [ "$USER" = '0' ]; then
-  if [ "${SET_PERMISSIONS}" = 'true']; then
+  if [ "${SET_PERMISSIONS}" = 'true' ]; then
     find /data -not -user plone -exec chown plone:plone {} \+
   fi
   sudo="gosu plone"

--- a/skeleton/docker-entrypoint.sh
+++ b/skeleton/docker-entrypoint.sh
@@ -13,9 +13,12 @@ export CLIENT_HOME=$CLIENT_HOME
 USER="$(id -u)"
 
 # Create directories to be used by Plone
+[ -z ${SET_PERMISSIONS+x} ] && export SET_PERMISSIONS=false
 mkdir -p /data/filestorage /data/blobstorage /data/cache /data/log $CLIENT_HOME
 if [ "$USER" = '0' ]; then
-  find /data -not -user plone -exec chown plone:plone {} \+
+  if [ "${SET_PERMISSIONS}" = 'true']; then
+    find /data -not -user plone -exec chown plone:plone {} \+
+  fi
   sudo="gosu plone"
 else
   sudo=""


### PR DESCRIPTION
Setting permissions on startup can take a long time on large installations and should only be necessary on first startup or to resolve permission issues.

This PR allows the initial permission set to be disabled by setting the env var `SET_PERMISSIONS = true`