### PR TITLE
Remove default accesslogging

### DIFF
--- a/skeleton/etc/zope.ini
+++ b/skeleton/etc/zope.ini
@@ -18,7 +18,6 @@ setup_console_handler = False
 [pipeline:main]
 pipeline =
     egg:Zope#httpexceptions
-    translogger
     zope
 
 [loggers]


### PR DESCRIPTION
It is currently not possible(?) to prevent default accesslogging to stdout.

It would make sense to make this configurable, but I can't see how to inject env vars into the zope.ini file on startup so this would be a bigger piece of work.

As we don't have a need for accesslogging here we are simply removing it from waitress.